### PR TITLE
Fixed Errors, Simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # deb_ez_install
-Bash scripts for easy installation on Debian based OS's
+Bash scripts for easy installation on Debian based OS's running KDE Plasma. It is intended to be used as tool for users who are not familiar or experienced with linux.
+
+**NOTE**: Functionality for this script has only been tested against Kubuntu.
+
+## Features
+
+Here is a list of the features available via this script.
+
+* Easy Package Manager
+  * Install package
+  * Update package
+  * Remove package
+* Backup Manager
+  * Create backup
+  * Restore backup
+  * Remove backup
+
+There are also some quality of life features, such as:
+* When installing VS Code, adding "*Open Folder with Visual Studio Code*" as a right click option.

--- a/launcher.sh
+++ b/launcher.sh
@@ -341,7 +341,7 @@ advanced_installer() {
                 install_apt_pkg "btop"
                 ;;
             code)
-                install_apk_pkg "code"
+                install_apt_pkg "code"
 
                 # Associate VS Code with folders (for right click open-with VS Code functionality)
                 if [ -f "$HOME/.config/mimeapps.list" ]; then
@@ -359,7 +359,7 @@ advanced_installer() {
                 install_apt_pkg "mullvad-vpn" "mullvad"
                 ;;
             net-tools)
-                install_apk_pkg "net-tools"
+                install_apt_pkg "net-tools"
                 ;;
             plex)
                 install_snap_pkg "plex-desktop" "plex"
@@ -408,7 +408,7 @@ advanced_installer() {
                 install_apt_pkg "vlc"
                 ;;
             yt-dlp)
-                install_apk_pkg "yt-dlp"
+                install_apt_pkg "yt-dlp"
                 ;;
             *)
                 echo -e "${RED}Unknown option: $option${NC}"


### PR DESCRIPTION
* Fixed errors from typos (called `install_apk_pkg` instead of `install_apt_pkg`)
* Added code as a menu option for advanced installer (added support for code previously, just forgot to list it)
* Simplified the loop case statement for the advanced installer (condensed code)